### PR TITLE
[Bug] Alsa presets ending with `-sw` should include `mixer-type=softw…

### DIFF
--- a/app/assets/alsa-presets.conf
+++ b/app/assets/alsa-presets.conf
@@ -5,6 +5,7 @@ x20.device=hw:x20
 
 aune-s6-sw.name=Aune S6 USB DAC
 aune-s6-sw.device=hw:DAC
+aune-s6-sw.mixer-type=software
 
 aune-s6.name=Aune S6 USB DAC
 aune-s6.device=hw:DAC
@@ -14,6 +15,7 @@ aune-s6.mixer-control=S6 USB DAC Output
 
 gustard-x12-sw.name=Gustard X12 USB DAC
 gustard-x12-sw.device=hw:x20
+gustard-x12-sw.mixer-type=software
 
 gustard-x12.name=Gustard X12 USB DAC
 gustard-x12.device=hw:x20
@@ -23,6 +25,7 @@ gustard-x12.mixer-control=xCORE USB Audio 2.0 Output
 
 gustard-u12-sw.name=Gustard U12 USB DDC
 gustard-u12-sw.device=hw:x20
+gustard-u12-sw.mixer-type=software
 
 gustard-u12.name=Gustard U12 USB DDC
 gustard-u12.device=hw:x20
@@ -32,6 +35,7 @@ gustard-u12.mixer-control=xCORE USB Audio 2.0 Output
 
 topping-d10-sw.name=Topping D10
 topping-d10-sw.device=hw:D10
+topping-d10-sw.mixer-type=software
 
 topping-d10.name=Topping D10
 topping-d10.device=hw:D10
@@ -44,6 +48,7 @@ hifiberry-dac-plus.device=hw:sndrpihifiberry
 
 fiio-e18-sw.name=FiiO E18
 fiio-e18-sw.device=hw:DACE18
+fiio-e18-sw.mixer-type=software
 
 fiio-e18.name=FiiO E18
 fiio-e18.device=hw:DACE18

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Date|Major Changes
 :---|:---
+2023-04-04|Alsa presets with `-sw` specify software volume (see issue[#281](https://github.com/GioF71/mpd-alsa-docker/issues/281))
 2023-03-27|Add `vanilla` images (see issue[#272](https://github.com/GioF71/mpd-alsa-docker/issues/272))
 2023-03-25|Add support for selection of repo binary (`FORCE_REPO_BINARY`)
 2023-03-24|Add armv6 support on debian-based images (see issue [#258](https://github.com/GioF71/mpd-alsa-docker/issues/258))


### PR DESCRIPTION
…are` #281