### PR TITLE
[Feature] Add an environment variable which allows using custom mpd.c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ jamendo.txt|Jamendo Credentials
 additional-alsa-presets.conf|Additional alsa presets
 additional-outputs.txt|Additional outputs, which will be added to the configuration file during the container startup phase
 asoundrc.txt|Alsa configuration file: this will be copied to `/home/mpd-user/.asoundrc` or to `/root/.asoundrc`, depending on user mode to be enabled or not
+override.mpd.conf|User provided mpd configuration file (see [#356](https://github.com/GioF71/mpd-alsa-docker/issues/356)). Use at your own risk. If this file is available, it will be used in the final phase of the run script instead of the generated file.
 
 For a reference for the structure of the credentials file, see the corresponding example file in the doc folder of the repository.
 

--- a/app/bin/run-mpd.sh
+++ b/app/bin/run-mpd.sh
@@ -784,6 +784,11 @@ elif [[ "${STDERR_ENABLED}" != "NO" && "${STDERR_ENABLED}" != "N" ]]; then
     exit 9
 fi
 
+if [ -f "/user/config/override.mpd.conf" ]; then
+    echo "Overriding generated mpd configuration file, use this feature at your own risk!"
+    MPD_ALSA_CONFIG_FILE=/user/config/override.mpd.conf
+fi
+
 CMD_LINE="$CMD_LINE --no-daemon $MPD_ALSA_CONFIG_FILE"
 echo "CMD_LINE=[$CMD_LINE]"
 if [ $USE_USER_MODE == "Y" ]; then


### PR DESCRIPTION
…onf file #356

Hello, I implemented this using the (already existing) volume /user/config
Just place (or anyway mount) a file named `override.mpd.conf` to use that file instead of the generated configuration file.
Hope this will work for you, enjoy!
