### PR TITLE
Add support to have FFMPEG as a decoder for MPD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN if [ "${USE_APT_PROXY}" = "Y" ]; then \
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y mpc ca-certificates
+RUN apt-get install -y mpc ca-certificates ffmpeg
 #RUN apt-get upgrade -y
 
 # install mpd from repo

--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ MAX_COMMAND_LIST_SIZE|The maximum size a command list in KBYTES, default is `204
 MAX_OUTPUT_BUFFER_SIZE|The maximum size of the output buffer to a client (maximum response size), in KBYTES, default is 8192 (8 MiB)
 STARTUP_DELAY_SEC|Delay before starting the application in seconds, defaults to `0`
 
+#### FFMPEG Decoder
+
+Please find here the variables used to configure FFMPEG.
+
+VARIABLE|DESCRIPTION
+:---|:---
+FFMPEG_MODE|Wether to enable FFMPEG decoder or `no`
+
 #### SOXR Plugin
 
 Please find here the variables used to configure the SOXR plugin.

--- a/app/bin/run-mpd.sh
+++ b/app/bin/run-mpd.sh
@@ -451,6 +451,14 @@ echo "  plugin \"wildmidi\"" >> $MPD_ALSA_CONFIG_FILE
 echo "  enabled \"no\"" >> $MPD_ALSA_CONFIG_FILE
 echo "}" >> $MPD_ALSA_CONFIG_FILE
 
+# wether to use ffmpeg as a decoder
+if [[ -n "${FFMPEG_ENABLED}" ]]; then
+    echo "decoder {" >> $MPD_ALSA_CONFIG_FILE
+    echo "  plugin \"ffmpeg\"" >> $MPD_ALSA_CONFIG_FILE
+    echo "  enabled \"yes\"" >> $MPD_ALSA_CONFIG_FILE
+    echo "}" >> $MPD_ALSA_CONFIG_FILE
+fi
+
 ## add input curl
 if [[ -z "${CURL_ENABLED}" || "${CURL_ENABLED^^}" == "YES" || "${CURL_ENABLED^^}" == "Y" ]]; then
     echo "input {" >> $MPD_ALSA_CONFIG_FILE


### PR DESCRIPTION
Some streams are not supported by ffmpeg, specially when loading a radio that has only an m3u8 url via upnp.