### PR TITLE
458 cannot override sox plugin values if using a preset

### DIFF
--- a/app/bin/run-mpd.sh
+++ b/app/bin/run-mpd.sh
@@ -625,45 +625,62 @@ if [[ "${SOXR_PLUGIN_ENABLE^^}" == "YES" || "${SOXR_PLUGIN_ENABLE^^}" == "Y" ]];
     fi
     if [ -n "${SOXR_PLUGIN_PRESET}" ]; then
         echo "Using soxr_preset: [${SOXR_PLUGIN_PRESET}]"
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_QUALITY}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_QUALITY=$sox_value
+        # we don't want to override explicitly set values
+        if [ -z "${SOXR_PLUGIN_QUALITY}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_QUALITY}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_QUALITY=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PRECISION}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_PRECISION=$sox_value
+        if [ -z "${SOXR_PLUGIN_PRECISION}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PRECISION}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_PRECISION=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PHASE_RESPONSE}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_PHASE_RESPONSE=$sox_value
+        if [ -z "${SOXR_PLUGIN_PHASE_RESPONSE}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PHASE_RESPONSE}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_PHASE_RESPONSE=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PASSBAND_END}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_PASSBAND_END=$sox_value
+        if [ -z "${SOXR_PLUGIN_PASSBAND_END}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_PASSBAND_END}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_PASSBAND_END=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_STOPBAND_BEGIN}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_STOPBAND_BEGIN=$sox_value
+        if [ -z "${SOXR_PLUGIN_STOPBAND_BEGIN}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_STOPBAND_BEGIN}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_STOPBAND_BEGIN=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_ATTENUATION}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_ATTENUATION=$sox_value
+        if [ -z "${SOXR_PLUGIN_ATTENUATION}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_ATTENUATION}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_ATTENUATION=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_FLAGS}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_FLAGS=$sox_value
+        if [ -z "${SOXR_PLUGIN_FLAGS}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_FLAGS}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_FLAGS=$sox_value
+            fi
         fi
-        sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_THREADS}"
-        sox_value="${soxr_plugin_presets[${sox_key}]}"
-        if [[ -v sox_value ]]; then
-            SOXR_PLUGIN_THREADS=$sox_value
+        if [ -z "${SOXR_PLUGIN_THREADS}" ]; then
+            sox_key="${SOXR_PLUGIN_PRESET}.${SOXR_PRESET_KEY_THREADS}"
+            sox_value="${soxr_plugin_presets[${sox_key}]}"
+            if [[ -v sox_value ]]; then
+                SOXR_PLUGIN_THREADS=$sox_value
+            fi
         fi
     fi
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Date|Major Changes
 :---|:---
+2026-04-11|Allow overriding sox parameters when a preset is selected (see issue [#458](https://github.com/GioF71/mpd-alsa-docker/issues/458))
 2026-04-11|Bump to version 0.24.9 (see issue [#456](https://github.com/GioF71/mpd-alsa-docker/issues/456))
 2026-02-24|Bump to version 0.24.8 (see issue [#453](https://github.com/GioF71/mpd-alsa-docker/issues/453))
 2025-10-23|Bump to version 0.24.6 (see issue [#451](https://github.com/GioF71/mpd-alsa-docker/issues/451))


### PR DESCRIPTION
- Now we can use the preset (e.g. `goldilocks`) and still tune some parameters, like e.g.:

SOXR_PLUGIN_ATTENUATION=3
SOXR_PLUGIN_PRECISION=32

to override defaults (respectively 4 and 28)
